### PR TITLE
useDatasource Composable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/storyblok",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Storyblok CMS integration with Vue Storefront",
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,8 +1,29 @@
-import { ApiContext, ApiResponse, ContentSearchParams } from './types'
+import {
+  ApiContext,
+  ApiContextConfig,
+  ApiResponse,
+  ContentSearchParams,
+  DatasourceEntriesParams,
+  DatasourceEntriesResponse,
+  IStoryblok,
+} from './types'
+import Storyblok from 'storyblok-js-client'
+
 import { Logger } from '@vue-storefront/core'
 import { nanoid } from 'nanoid'
 import { errorMessage } from './helpers/constants'
 import { extractNestedComponents } from './helpers'
+
+const instantiateClient = (client: IStoryblok, config: ApiContextConfig): Storyblok => {
+  const { token, cacheProvider } = config
+  return new client({
+    accessToken: token,
+    cache: {
+      clear: 'auto',
+      type: cacheProvider,
+    },
+  })
+}
 
 export const getContent = async (
   { client, config }: ApiContext,
@@ -19,18 +40,13 @@ export const getContent = async (
   if (!url && !id && !custom) {
     return Logger.warn(`${errorMessage.GENERAL} ${errorMessage.EMPTY_ID}`)
   }
-  const { token, cacheProvider } = config
-  const Storyblok = new client({
-    accessToken: token,
-    cache: {
-      clear: 'auto',
-      type: cacheProvider,
-    },
-  })
-  const resolveCustomSearch = id ? { by_uuids_ordered: id } : custom || {}
   if (!id && custom && typeof custom !== 'object') {
     return Logger.warn(`${errorMessage.GENERAL} ${errorMessage.WRONG_CUSTOM}`)
   }
+
+  const Storyblok = instantiateClient(client, config);
+  const resolveCustomSearch = id ? { by_uuids_ordered: id } : custom || {}
+
   try {
     const { data }: { data: ApiResponse } = await Storyblok.get(
       `cdn/stories/${id || custom ? '' : url}`,
@@ -45,6 +61,34 @@ export const getContent = async (
     return data.story
       ? extractNestedComponents(data.story)
       : extractNestedComponents({ content: data.stories }, true) || []
+  } catch (error) {
+    Logger.warn(`${errorMessage.GENERAL}`, error)
+    return []
+  }
+}
+
+export const getDatasourceEntries = async (
+  { client, config }: ApiContext,
+  { slug, dimension, cache, page, per_page }: DatasourceEntriesParams,
+): Promise<[] | void | {}> => {
+  if (!slug) {
+    return Logger.warn(`${errorMessage.GENERAL} ${errorMessage.EMPTY_DATASOURCE}`)
+  }
+
+  const Storyblok = instantiateClient(client, config);
+
+  try {
+    const { data }: { data: DatasourceEntriesResponse } = await Storyblok.get(
+      `cdn/datasource_entries/`,
+      {
+        datasource: slug,
+        dimension,
+        page,
+        per_page,
+        ...((!cache ? { cv: nanoid() } : {}) as any),
+      },
+    )
+    return data.datasource_entries
   } catch (error) {
     Logger.warn(`${errorMessage.GENERAL}`, error)
     return []

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -1,4 +1,5 @@
 import { useContent } from './useContent'
+import { useDatasource } from './useDatasource'
 import { extractComponents } from './renderContent'
 
-export { useContent, extractComponents }
+export { useContent, useDatasource, extractComponents }

--- a/src/composables/useDatasource.ts
+++ b/src/composables/useDatasource.ts
@@ -1,0 +1,13 @@
+import { useContentFactory, UseContent, Context } from '@vue-storefront/core'
+import { DatasourceEntriesParams } from '../types'
+
+const search = async (
+  context: Context,
+  params: DatasourceEntriesParams,
+): Promise<any> => {
+  return context.$sb.api.getDatasourceEntries(params)
+}
+const useDatasource: (cacheId: string) => UseContent<any, DatasourceEntriesParams> =
+  useContentFactory<any, DatasourceEntriesParams>({ search })
+
+export { useDatasource }

--- a/src/context.d.ts
+++ b/src/context.d.ts
@@ -1,5 +1,5 @@
 import { IntegrationContext } from '@vue-storefront/core'
-import { ContentSearchParams } from './types'
+import { ContentSearchParams, DatasourceEntriesParams } from './types'
 
 declare module '@vue-storefront/core' {
   export interface Context {
@@ -8,6 +8,7 @@ declare module '@vue-storefront/core' {
       ContentSearchParams,
       {
         getContent: (params: ContentSearchParams) => void
+        getDatasourceEntries: (params: DatasourceEntriesParams) => void
       }
     >
   }

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -1,5 +1,6 @@
 export const errorMessage = {
   GENERAL: "Can't get data from Storyblok.",
   EMPTY_ID: 'Define story id, url or custom query object.',
+  EMPTY_DATASOURCE: 'Define datasource slug.',
   WRONG_CUSTOM: 'Custom query wrong format. Define proper object.',
 }

--- a/src/index.server.ts
+++ b/src/index.server.ts
@@ -2,7 +2,7 @@ import { apiClientFactory } from '@vue-storefront/core'
 import { ApiContext, ContentSearchParams } from './types'
 import StoryblokClient from 'storyblok-js-client'
 
-import { getContent } from './api'
+import { getContent, getDatasourceEntries } from './api'
 
 const setup = ({ token, cacheProvider }: ContentSearchParams): ApiContext => {
   return {
@@ -18,6 +18,7 @@ const { createApiClient } = apiClientFactory({
   onCreate: setup,
   api: {
     getContent,
+    getDatasourceEntries,
   },
 } as any)
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,8 +1,18 @@
-import { StoryblokCache } from 'storyblok-js-client'
+import Storyblok, { StoryblokCache, StoryblokConfig } from 'storyblok-js-client'
 
-export interface ContentSearchParams {
+export interface IStoryblok {
+  new(config: StoryblokConfig): Storyblok;
+}
+export interface ApiContextConfig {
   token: string
-  cacheProvider: StoryblokCache
+  cacheProvider?: 'memory'
+}
+export interface ApiContext {
+  client: IStoryblok
+  config: ApiContextConfig
+}
+
+export interface ContentSearchParams extends ApiContextConfig {
   cache?: boolean
   version?: Version
   id?: string
@@ -15,10 +25,6 @@ export type Version = 'draft' | 'published'
 export interface CustomSearch {
   field: string
   value: string
-}
-export interface ApiContext {
-  client: any
-  config: ContentSearchParams
 }
 export interface Content {
   content: any
@@ -37,4 +43,23 @@ export interface Component {
 }
 export interface Image {
   image: string
+}
+
+export interface DatasourceEntriesParams extends ApiContextConfig {
+  cache?: boolean
+  slug: string
+  dimension?: string
+  page?: number
+  per_page?: number
+}
+
+export interface DatasourceEntry {
+  id: String
+  name: String
+  value: String
+  dimension_value?: String
+}
+
+export interface DatasourceEntriesResponse {
+  datasource_entries?: DatasourceEntry[]
 }


### PR DESCRIPTION
Hey !

Since vue-storefront/storyblok is our bridge to fetch sb stories, i think it would be great to handle sb datasources as well.

Included in the PR :
- "useDatasource" composable to fetch datasource entries
- Minor type fixes (Storyblok client and CacheProvider)

Not sure it sticks to your standards, let me know if there's anything to change