### PR TITLE
Preserve pagination data in API response

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -32,7 +32,7 @@ export const getContent = async (
     return Logger.warn(`${errorMessage.GENERAL} ${errorMessage.WRONG_CUSTOM}`)
   }
   try {
-    const { data }: { data: ApiResponse } = await Storyblok.get(
+    const { data, perPage, total }: { data: ApiResponse, perPage: number, total: number } = await Storyblok.get(
       `cdn/stories/${id || custom ? '' : url}`,
       {
         ...((!cache ? { cv: nanoid() } : {}) as any),
@@ -42,9 +42,13 @@ export const getContent = async (
         version,
       },
     )
-    return data.story
+    const extractedComponents = data.story
       ? extractNestedComponents(data.story)
-      : extractNestedComponents({ content: data.stories }, true) || []
+      : extractNestedComponents({ content: data.stories }, true)
+
+    if (perPage !== undefined) extractedComponents.perPage = perPage
+    if (total !== undefined) extractedComponents.total = total
+    return extractedComponents
   } catch (error) {
     Logger.warn(`${errorMessage.GENERAL}`, error)
     return []

--- a/src/api.ts
+++ b/src/api.ts
@@ -46,8 +46,10 @@ export const getContent = async (
       ? extractNestedComponents(data.story)
       : extractNestedComponents({ content: data.stories }, true)
 
-    if (perPage !== undefined) extractedComponents.perPage = perPage
-    if (total !== undefined) extractedComponents.total = total
+    if (perPage !== undefined)
+      (extractedComponents as Record<string, any>).perPage = perPage
+    if (total !== undefined)
+      (extractedComponents as Record<string, any>).total = total
     return extractedComponents
   } catch (error) {
     Logger.warn(`${errorMessage.GENERAL}`, error)

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -30,7 +30,7 @@ export const extractNestedComponents: (
     | Content[]
     | Content,
   stories?: boolean,
-) => void | boolean = (data: Content, stories = false) => {
+) => Record<string, any> = (data: Content, stories = false) => {
   if (data.content) {
     extractNestedComponents(data.content)
     if (Array.isArray(data.content)) {

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -30,7 +30,7 @@ export const extractNestedComponents: (
     | Content[]
     | Content,
   stories?: boolean,
-) => Record<string, any> = (data: Content, stories = false) => {
+) => void | boolean | Record<string, any> = (data: Content, stories = false) => {
   if (data.content) {
     extractNestedComponents(data.content)
     if (Array.isArray(data.content)) {


### PR DESCRIPTION
This PR preserver `total` and `perPage` properties returned by `Storyblok.get()` along with the components' data.

These properties are necessary to build pagination in the Storyblok blog template.