### PR TITLE
Asynchronous Storyblok Bridge loading

### DIFF
--- a/nuxt/index.js
+++ b/nuxt/index.js
@@ -7,12 +7,6 @@ export default function storyblok(moduleOptions) {
     ...storyblok,
     ...moduleOptions,
   }
-  if (options.jsBridge && head) {
-    const scripts = head.script
-    scripts.push({
-      src: `${options.jsBridge}`,
-    })
-  }
   this.addPlugin({
     src: path.resolve(__dirname, 'plugin.js'),
     options,

--- a/src/helpers/storyblokBridge.js
+++ b/src/helpers/storyblokBridge.js
@@ -1,18 +1,36 @@
+const createStoryblokBridge = (content, events, relations) => {
+  if (window) {
+    // eslint-disable-next-line
+    const instance = new StoryblokBridge({
+      resolveRelations: relations,
+    });
+    instance.on(events, (payload) => {
+      content.content = {
+        ...payload.story.content,
+        _meta: payload.story,
+      };
+    });
+  }
+};
+
 export const storyblokBridge = (
   content = { content: {} },
   events = ['change', 'input'],
   relations = [],
 ) => {
-  if (window) {
-    // eslint-disable-next-line
-    const instance = new StoryblokBridge({
-      resolveRelations: relations,
-    })
-    instance.on(events, (payload) => {
-      content.content = {
-        ...payload.story.content,
-        _meta: payload.story,
-      }
-    })
+  const isInsideStoryblokPreview = window.location.ancestorOrigins.contains('http://app.storyblok.com');
+  if (!isInsideStoryblokPreview) return
+
+  const existingScript = document.getElementById("storyblokBridge");
+  if (!existingScript) {
+    const script = document.createElement("script");
+    script.src = "//app.storyblok.com/f/storyblok-v2-latest.js";
+    script.id = "storyblokBridge";
+    document.body.appendChild(script);
+    script.onload = () => {
+      createStoryblokBridge(content, events, relations);
+    };
+  } else {
+      createStoryblokBridge(content, events, relations);
   }
 }


### PR DESCRIPTION
Along with Piotr Grzywa, we've discovered that the Storyblok Bridge script is considered a render-blocking resource:

![image](https://user-images.githubusercontent.com/39009379/144846968-00909e7d-c100-481e-9242-74e171d6d510.png)

We think it might be a good idea to load the Bridge script asynchronously, as described [here](https://www.storyblok.com/docs/Guides/storyblok-latest-js#loading-the-bridge-asynchronously).

This PR contains no breaking changes. It only transfers the script addition logic from the module into the `StoryblokBridge` helper. The script addition logic has been enhanced according to the SB docs:

```
function loadBridge(callback) {
    const existingScript = document.getElementById("storyblokBridge");
    if (!existingScript) {
      const script = document.createElement("script");
      script.src = "//app.storyblok.com/f/storyblok-v2-latest.js";
      script.id = "storyblokBridge";
      document.body.appendChild(script);
      script.onload = () => {
        callback();
      };
    } else {
      callback();
    }
}
```

I've also added a check whether we are viewing the app in the Storyblok editor or not. If not - we do not load the Bridge script at all. One thing I'm worried about is the way the check is performed. Storyblok suggests looking for `window.location.search.includes('_storyblok')` but for me, it wasn't there even when I was inside the preview.

I've decided to go with the `window.location.ancestorOrigins.contains('http://app.storyblok.com')` but perhaps you guys have a better idea how to do it. 

The Storyblok Bridge can be imported and initiated in our Vue components the exact same way it has been up to this point.
