### PR TITLE
Resolve content links

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -13,6 +13,7 @@ export const getContent = async (
     cache = true,
     locale,
     relations,
+    links,
     version = 'published',
   }: ContentSearchParams,
 ): Promise<[] | void | {}> => {
@@ -37,6 +38,7 @@ export const getContent = async (
       {
         ...((!cache ? { cv: nanoid() } : {}) as any),
         ...resolveCustomSearch,
+        resolve_links: links,
         resolve_relations: relations,
         language: locale,
         version,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -10,6 +10,7 @@ export interface ContentSearchParams {
   custom?: {} | CustomSearch
   locale?: string
   relations?: string
+  links?: string
 }
 export type Version = 'draft' | 'published'
 export interface CustomSearch {


### PR DESCRIPTION
Allows us to use the `resolve_links` parameter from storyblok-js-client 