### PR TITLE
[IN-3875] Update storyblok dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Full documentation can be found [here](https://docs.vuestorefront.io/storyblok).
 Install module into your app.
 
 ```bash
-npm install @vue-storefront/storyblok storyblok-vue  --save
+npm install @vue-storefront/storyblok @storyblok/vue-2@1.3.1  --save
 ```
 
 or
 
 ```bash
-yarn add @vue-storefront/storyblok storyblok-vue
+yarn add @vue-storefront/storyblok @storyblok/vue-2@1.3.1
 ```
 
 Check the [documentation](https://docs.vuestorefront.io/storyblok) for all the instructions and guidelines.

--- a/nuxt/plugin.js
+++ b/nuxt/plugin.js
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import StoryblokVue from 'storyblok-vue'
+import StoryblokVue from '@storyblok/vue-2'
 import { integrationPlugin } from '@vue-storefront/core'
 
 Vue.use(StoryblokVue)

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "typescript": "^4.4.4"
   },
   "peerDependencies": {
-    "storyblok-vue": "^1.0.5"
+    "@storyblok/vue-2": "1.3.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
`storyblok-vue` is deprecated: [npm: storyblok-vue](https://www.npmjs.com/package/storyblok-vue)

It recommends moving to this package: [npm: @storyblok/vue-2](https://www.npmjs.com/package/@storyblok/vue-2/v/1.3.1) 

Using [version 1.3.1](https://www.npmjs.com/package/@storyblok/vue-2?activeTab=versions) of the above would mean no breaking changes. 

This would be the latest we can move to because [version 2.0](https://github.com/storyblok/storyblok-vue-2/releases/tag/v2.0.0) requires Vue 2.7 which VSF 2 doesn’t support.